### PR TITLE
Add top-describe-path rule

### DIFF
--- a/docs/rules/top-describe-path.md
+++ b/docs/rules/top-describe-path.md
@@ -1,0 +1,42 @@
+# Ensure that the top `describe` call in each test file use the correct path (top-describe-path)
+
+We use `mocha` in many of our projects and have adopted the convention of using `__filename` as the description in the root `describe` in each test file. That way it's easy to find a failing test.
+It is easier and less error-prone to write `__filename` then the actual path.
+The downside of using `__filename` is that editors cannot understand where the failing test is located. If every `describe` use a static string then it's possible to jump to a test case.
+It also looks a bit ugly with all the absolute paths. It's nicer if they are relative to the project.
+
+
+## Rule Details
+
+This rule aims to assert that the top `describe` uses the correct relative path.
+
+If the `--fix` flag is used, the correct path is inserted instead of the first argument to `describe`.
+
+
+The following patterns are considered warnings:
+
+```js
+// Use of the __filename identifier
+describe(__filename, function() {
+});
+
+// Incorrect path
+describe('foo', function() {
+});
+```
+
+The following patterns are not warnings:
+
+```js
+describe('tests/lib/rules/top-describe-path.js', function() {
+
+  describe('foo', function() {
+  });
+
+});
+```
+
+## When Not To Use It
+
+Should only be used in the test dir.
+If a project does not use `mocha` with the BDD UI or does not follow this convention then this rule should not be used.

--- a/lib/rules/top-describe-path.js
+++ b/lib/rules/top-describe-path.js
@@ -1,0 +1,49 @@
+"use strict";
+
+const path = require('path');
+
+module.exports = function(context) {
+
+  function getCurrentPath() {
+    return path.relative(process.cwd(), context.getFilename());
+  }
+
+  function isTopDescribe(n) {
+    return n.type === 'ExpressionStatement' &&
+           n.expression.type === 'CallExpression' &&
+           n.expression.callee.type === 'Identifier' &&
+           n.expression.callee.name === 'describe';
+  }
+
+  function getTopDescribeCallExpression(program_node) {
+    for (const n of program_node.body) {
+      if (isTopDescribe(n)) {
+        return n.expression;
+      }
+    }
+    return null;
+  }
+
+  return {
+    Program: function(program_node) {
+      const top_desc = getTopDescribeCallExpression(program_node);
+      if (!top_desc || !top_desc.arguments.length) {
+        return;
+      }
+
+      const arg = top_desc.arguments[0];
+      const filepath = getCurrentPath();
+      if (arg.type === 'Literal' && arg.value === filepath) {
+        return;
+      }
+
+      context.report({
+        node: arg,
+        message: 'Unexpected path in top describe',
+        fix: fixer => fixer.replaceText(arg, '\'' + filepath + '\''),
+      });
+    },
+  };
+};
+
+module.exports.schema = [];

--- a/tests/lib/rules/top-describe-path.js
+++ b/tests/lib/rules/top-describe-path.js
@@ -1,0 +1,61 @@
+"use strict";
+
+var rule = require("../../../lib/rules/top-describe-path");
+var RuleTester = require("eslint").RuleTester;
+
+var ruleTester = new RuleTester();
+ruleTester.run("top-describe-path", rule, {
+  valid: [
+    {
+      code: "describe('tests/lib/rules/top-describe-path.js', function() { });",
+      filename: __filename,
+    },
+    {
+      code: "describe('tests/lib/rules/top-describe-path.js', function() {  describe('foo', function() { });  });",
+      filename: __filename,
+    },
+    {
+      code: "var x = 1; describe('tests/lib/rules/top-describe-path.js', function() {  describe('foo', function() { });  });",
+      filename: __filename,
+    },
+  ],
+
+  invalid: [
+    {
+      code: "describe(__filename, function() { });",
+      output: "describe('tests/lib/rules/top-describe-path.js', function() { });",
+      filename: __filename,
+      errors: [{
+        message: "Unexpected path in top describe",
+        type: "Identifier"
+      }],
+    },
+    {
+      code: "describe(__filename, function() {  describe('foo', function() { });  });",
+      output: "describe('tests/lib/rules/top-describe-path.js', function() {  describe('foo', function() { });  });",
+      filename: __filename,
+      errors: [{
+        message: "Unexpected path in top describe",
+        type: "Identifier"
+      }],
+    },
+    {
+      code: "describe('incorrect path', function() { });",
+      output: "describe('tests/lib/rules/top-describe-path.js', function() { });",
+      filename: __filename,
+      errors: [{
+        message: "Unexpected path in top describe",
+        type: "Literal"
+      }],
+    },
+    {
+      code: "describe('incorrect path', function() {  describe('foo', function() { });  });",
+      output: "describe('tests/lib/rules/top-describe-path.js', function() {  describe('foo', function() { });  });",
+      filename: __filename,
+      errors: [{
+        message: "Unexpected path in top describe",
+        type: "Literal"
+      }],
+    },
+  ],
+});


### PR DESCRIPTION
## Ensure that the top `describe` call in each test file use the correct path (top-describe-path)

We use `mocha` in many of our projects and have adopted the convention of using `__filename` as the description in the root `describe` in each test file. That way it's easy to find a failing test.
It is easier and less error-prone to write `__filename` then the actual path.
The downside of using `__filename` is that editors cannot understand where the failing test is located. If every `describe` use a static string then it's possible to jump to a test case.
It also looks a bit ugly with all the absolute paths. It's nicer if they are relative to the project.


### Rule Details

This rule aims to assert that the top `describe` uses the correct relative path.

If the `--fix` flag is used, the correct path is inserted instead of the first argument to `describe`.


The following patterns are considered warnings:

```js
// Use of the __filename identifier
describe(__filename, function() {
});

// Incorrect path
describe('foo', function() {
});
```

The following patterns are not warnings:

```js
describe('tests/lib/rules/top-describe-path.js', function() {

  describe('foo', function() {
  });

});
```
