### PR TITLE
feat(rule): add no-logger-format-payload

### DIFF
--- a/docs/rules/no-logger-format-payload.md
+++ b/docs/rules/no-logger-format-payload.md
@@ -1,0 +1,41 @@
+# Remove use of the `formatPayload` function (no-logger-format-payload)
+
+This rule is meant to help us remove all usage of `logger.formatPayload(data)`.
+
+This rule is fixable. Use `--fix`...
+
+## Examples
+
+```js
+logger.info(logger.formatPayload({ foo: 123 }), 'my log message');
+// will be transformed to:
+logger.info({ foo: 123 }, 'my log message');
+```
+
+```js
+foo_logger.info(foo_logger.formatPayload({ foo: 123 }), 'my log message');
+// will be transformed to:
+foo_logger.info({ foo: 123 }, 'my log message');
+```
+
+```js
+const payload = logger.formatPayload({ foo: 123 });
+logger.info(payload, 'my log message');
+// will be transformed to:
+const payload = { foo: 123 };
+logger.info(payload, 'my log message');
+```
+
+## Examples of valid code
+
+These will not trigger the linter
+
+```js
+logger.info({ foo: 123 }, 'my log message');
+
+const fn = logger.formatPayload;
+
+someOtherThing.formatPayload({});
+
+formatPayload({});
+```

--- a/lib/rules/no-logger-format-payload.js
+++ b/lib/rules/no-logger-format-payload.js
@@ -1,0 +1,21 @@
+"use strict";
+
+module.exports = {
+  meta: {
+    fixable: "code",
+    schema: []
+  },
+  create: function(context) {
+    return {
+      "CallExpression[callee.type=MemberExpression][callee.object.name=/[Ll]og/][callee.property.name='formatPayload']": function(node) {
+        context.report({
+          node: node,
+          message: "Use of the formatPayload function from @springworks/logger-factory",
+          fix: function(fixer) {
+            return fixer.replaceText(node, context.getSourceCode().getText(node.arguments[0]));
+          }
+        });
+      }
+    };
+  }
+};

--- a/tests/lib/rules/no-logger-format-payload.js
+++ b/tests/lib/rules/no-logger-format-payload.js
@@ -1,0 +1,45 @@
+"use strict";
+
+var rule = require("../../../lib/rules/no-logger-format-payload");
+var RuleTester = require("eslint").RuleTester;
+
+var message = "Use of the formatPayload function from @springworks/logger-factory";
+
+var ruleTester = new RuleTester();
+ruleTester.run("no-logger-format-payload", rule, {
+
+  valid: [
+    { code: "logger.info({ foo: 123 }, 'my log message');" },
+    { code: "var fn = logger.formatPayload" },
+    { code: "someOtherThing.formatPayload({})" },
+    { code: "formatPayload({})" },
+  ],
+
+  invalid: [
+    {
+      code: "logger.info(logger.formatPayload({ foo: 123 }), 'my log message');",
+      output: "logger.info({ foo: 123 }, 'my log message');",
+      errors: [{ message: message, type: "CallExpression" }],
+    },
+    {
+      code: "log.info(log.formatPayload({ foo: 123 }), 'my log message');",
+      output: "log.info({ foo: 123 }, 'my log message');",
+      errors: [{ message: message, type: "CallExpression" }],
+    },
+    {
+      code: "foo_logger.info(foo_logger.formatPayload({ foo: 123 }), 'my log message');",
+      output: "foo_logger.info({ foo: 123 }, 'my log message');",
+      errors: [{ message: message, type: "CallExpression" }],
+    },
+    {
+      code: "fooLogger.info(fooLogger.formatPayload({ foo: 123 }), 'my log message');",
+      output: "fooLogger.info({ foo: 123 }, 'my log message');",
+      errors: [{ message: message, type: "CallExpression" }],
+    },
+    {
+      code: "var payload = logger.formatPayload({ foo: 123 }); logger.info(payload, 'my log message');",
+      output: "var payload = { foo: 123 }; logger.info(payload, 'my log message');",
+      errors: [{ message: message, type: "CallExpression" }],
+    },
+  ],
+});


### PR DESCRIPTION
# Remove use of the `formatPayload` function (no-logger-format-payload)

This rule is meant to help us remove all usage of `logger.formatPayload(data)`.

This rule is fixable. Use `--fix`...

## Examples

```js
logger.info(logger.formatPayload({ foo: 123 }), 'my log message');
// will be transformed to:
logger.info({ foo: 123 }, 'my log message');
```

```js
foo_logger.info(foo_logger.formatPayload({ foo: 123 }), 'my log message');
// will be transformed to:
foo_logger.info({ foo: 123 }, 'my log message');
```

```js
const payload = logger.formatPayload({ foo: 123 });
logger.info(payload, 'my log message');
// will be transformed to:
const payload = { foo: 123 };
logger.info(payload, 'my log message');
```

## Examples of valid code

These will not trigger the linter

```js
logger.info({ foo: 123 }, 'my log message');

const fn = logger.formatPayload;

someOtherThing.formatPayload({});

formatPayload({});
```